### PR TITLE
A simple change where we return None if no theme is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+CHANGELOG
+=========
+
+v1.0
+-----
+
+  * First major release
+  * All site to fall back to no theme if no theme is available (powellc)
+
+
+v0.1
+----
+
+  * Initial release

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ classifiers = meta_files['CLASSIFIERS.txt'].split('\n')
 classifiers.remove('')
 
 setup(name='django-themes',
-      version='0.1',
+      version='0.2',
       description='A powerful application that can be used to develop themes to completely reskin your django apps.',
       long_description=meta_files['README.md'],
       classifiers=classifiers,

--- a/themes/context_processors.py
+++ b/themes/context_processors.py
@@ -9,7 +9,7 @@ def _default_theme(request):
         try:
             theme = Theme.objects.get_list_by_request(request)[0]
         except IndexError:
-            raise Http404('You must create a theme in the system.')
+            theme = None
 
     return theme 
 


### PR DESCRIPTION
When I first installed this I couldn't find an obvious way to add a theme without hitting the 404 error in the context processor when it couldn't find a theme. That seemed like chasing my tail, so I'm just returning None for the theme if it can't find one, which works in the template because it just doesn't include any theme style files.

Feel free to reject this as wontfix if you don't like that behaviour.
